### PR TITLE
Allow PR Body labels to override labels inherited from PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project tries to adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Upcoming]
+
+### Changed
+- [#16](https://github.com/oscar-system/update-release-notes/pull/16) Allow PR Body labels to
+  override labels inherited from PR in the case of `release notes: use body` label.
+
 ## 1.2 - 2026-06-24
 
 ### Added

--- a/release-notes.py
+++ b/release-notes.py
@@ -383,6 +383,14 @@ def split_pr_into_changelog(prs: List):
                                 "This might result in a TODO changelog item!"
                             )
                             continue
+                        # if PR Body has a label which conflicts with PR label, PR body label wins
+                        # since only label of PRTYPES is allowed, in this conflict, we have to
+                        # also remove any other label from the child PR for PRTYPES
+                        if label in PRTYPES:
+                            cpr['labels'] = [l for l in cpr['labels'] if l['name'] not in PRTYPES]
+                        # same conflict resolution logic as above, but for PR TOPICS
+                        elif label in TOPICS:
+                            cpr['labels'] = [l for l in cpr['labels'] if l['name'] not in TOPICS]
                         cpr['labels'].append({'name': label})
                     mindex = mans.span()[0]
                     line = line[0:mindex]


### PR DESCRIPTION
Fixes the issue discovered by @lgoettgens where having conflicting labels in the PR itself v/s in the PR body would result in strange behaviour.

I tested the symptomatic PR in Oscar.jl against my changes, and the new results seem to be what was desired.

```diff
+### Changes related to the package AbstractAlgebra
+
+- [#6051](https://github.com/oscar-system/Oscar.jl/pull/6051) Update AbstractAlgebra to v0.50
+
+### Changes related to the package Nemo
+
+- [#6051](https://github.com/oscar-system/Oscar.jl/pull/6051) Update Nemo to v0.56
```